### PR TITLE
Different user edge weights according to edge types

### DIFF
--- a/twarc_network/__init__.py
+++ b/twarc_network/__init__.py
@@ -169,7 +169,7 @@ def add(g, nodes_type, from_user, from_id, to_user, to_id, edge_type, created_at
     # storing start_date will allow for timestamps for gephi timeline, where nodes
     # will appear on screen at their start date and stay on forever after
 
-    if nodes_type in ["users", "hashtags"] and to_user:
+    if nodes_type == "hashtags" and to_user:
         g.add_node(from_user, screen_name=from_user, start_date=created_at)
         g.add_node(to_user, screen_name=to_user, start_date=created_at)
 
@@ -186,6 +186,24 @@ def add(g, nodes_type, from_user, from_id, to_user, to_id, edge_type, created_at
         else:
             g.add_node(to_id)
         g.add_edge(from_id, to_id, type=edge_type)
+
+    elif nodes_type == "users" and to_user:
+        g.add_node(from_user, screen_name=from_user, start_date=created_at)
+        g.add_node(to_user, screen_name=to_user, start_date=created_at)
+
+        if g.has_edge(from_user, to_user):
+            weights = g[from_user][to_user]
+        else:
+            g.add_edge(from_user, to_user)
+            weights = {
+                "weight":  0,
+                "retweet": 0,
+                "reply":   0,
+                "quote":   0,
+            }
+        weights["weight"]  += 1
+        weights[edge_type] += 1
+        g[from_user][to_user].update(weights)
 
 
 def to_json(g):


### PR DESCRIPTION
Currently, when `node_type` is `users` and a user A has interacted with user B in different forms (like retweet and reply), we obtain an edge with the following attributes:
- `type`: the type of the first interaction between A and B, and
- `weight`: the total number of interactions, regardless of its type.

I think that it would have more sense to obtain the following attributes:
- `weight`: the total number of interactions, regardless of its type,
- `retweet`: the number of retweets,
- `reply`: the number of replies, and
- `quote`: the number of quotes.

`weight` would be just the sum of the other three attributes, but maybe it is good to keep it for compatibility with old versions and because Networkx use it as the default weight.

By the way, I imagine that all edges were added by the same function `add` regardless of the node type in order to reuse the same code. But after this commit, where no code is shared between different node types, it seems that using three different add functions (one for each node type) with different parameters would be cleaner. But maybe this change should be done in another pull request?