### PR TITLE
Remove attribute hardcoding in json

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     description="Generate network visualizations for Twitter data",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    python_requires=">=3.3",
+    python_requires=">=3.5",
     install_requires=["twarc", "networkx", "pydot"],
     setup_data={"twarc_network": ["twarc_network/index.html"]},
     package_data={"twarc_network": ["index.html"]},

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     description="Generate network visualizations for Twitter data",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    python_requires=">=3.5",
+    python_requires=">=3.3",
     install_requires=["twarc", "networkx", "pydot"],
     setup_data={"twarc_network": ["twarc_network/index.html"]},
     package_data={"twarc_network": ["index.html"]},

--- a/twarc_network/__init__.py
+++ b/twarc_network/__init__.py
@@ -200,9 +200,13 @@ def add_hashtag_edge(g, from_hashtag, to_hashtag, created_at):
 def to_json(g):
     j = {"nodes": [], "links": []}
     for node_id, attrs in g.nodes(data=True):
-        j["nodes"].append({**{"id": node_id}, **attrs})
+        node = {"id": node_id}
+        node.update(attrs)
+        j["nodes"].append(node)
     for source, target, attrs in g.edges(data=True):
-        j["links"].append({**{"source": source, "target":target}, **attrs})
+        link = {"source": source, "target": target}
+        link.update(attrs)
+        j["links"].append(link)
     return j
 
 

--- a/twarc_network/__init__.py
+++ b/twarc_network/__init__.py
@@ -200,9 +200,9 @@ def add_hashtag_edge(g, from_hashtag, to_hashtag, created_at):
 def to_json(g):
     j = {"nodes": [], "links": []}
     for node_id, attrs in g.nodes(data=True):
-        j["nodes"].append({"id": node_id} | attrs)
+        j["nodes"].append({**{"id": node_id}, **attrs})
     for source, target, attrs in g.edges(data=True):
-        j["links"].append({"source": source, "target":target} | attrs)
+        j["links"].append({**{"source": source, "target":target}, **attrs})
     return j
 
 

--- a/twarc_network/__init__.py
+++ b/twarc_network/__init__.py
@@ -199,18 +199,10 @@ def add_hashtag_edge(g, from_hashtag, to_hashtag, created_at):
 
 def to_json(g):
     j = {"nodes": [], "links": []}
-    for node_id, node_attrs in g.nodes(True):
-        j["nodes"].append(
-            {
-                "id": node_id,
-                "type": node_attrs.get("type"),
-                "screen_name": node_attrs.get("screen_name"),
-            }
-        )
+    for node_id, attrs in g.nodes(data=True):
+        j["nodes"].append({"id": node_id} | attrs)
     for source, target, attrs in g.edges(data=True):
-        j["links"].append(
-            {"source": source, "target": target, "type": attrs.get("type")}
-        )
+        j["links"].append({"source": source, "target":target} | attrs)
     return j
 
 


### PR DESCRIPTION
Currently, when using the json format, nodes only have id, type and screen_name as attributes, and edges only have source, target and type. I think that it would be better to have all the attributes present in the graph.