### PR TITLE
Added license for pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,10 @@ setuptools.setup(
     description="Generate network visualizations for Twitter data",
     long_description=long_description,
     long_description_content_type="text/markdown",
+    license="MIT",
+    classifiers=[
+        "License :: OSI Approved :: MIT License",
+    ],
     python_requires=">=3.3",
     install_requires=["twarc", "networkx", "pydot"],
     setup_data={"twarc_network": ["twarc_network/index.html"]},


### PR DESCRIPTION
Currently there is no license information in the [PyPI page](https://pypi.org/project/twarc-network/). With this change, there will be the license information when the package is updated.