### PR TITLE
Mention edges

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Build Status](https://github.com/docnow/twarc-network/workflows/tests/badge.svg)](https://github.com/DocNow/twarc-network/actions/workflows/main.yml)
 
-*twarc-network* builds a reply, quote and retweet network from a file of tweets
+*twarc-network* builds a reply, quote, retweet and mention network from a file of tweets
 that you've collected using twarc. It will write out the network as a [gexf],
 [gml], [dot], json, csv or html file. It uses [networkx] for the graph model,
 [pydot] for dot output, and [d3] for the html presentation. 
@@ -69,8 +69,10 @@ can visualize a network where nodes are hashtags:
 ## Changing the Edges
 
 By default, when user and tweet graphs are built,
-all types of interactions (retweet, reply or quote) are used as edges,
-but you can also limit the types considered.
+all types of interactions are used as edges:
+Retweet, reply or quote in the case of tweets;
+retweet, reply, quote or mention in the case of users.
+But you can also limit the types considered.
 For example, if you only want retweet edges, you can:
 
     twarc2 network tweets.jsonl tweets.html --edges retweet
@@ -119,8 +121,10 @@ The possible edge attributes are the following:
   the number of replies the source has made to the target.
 - `quote`: When the nodes are users,
   the number of quotes the source has made to the target.
+- `mention`: When the nodes are users,
+  the number of mentions the source has made to the target.
 - `weight`:
-  When the nodes are users, the sum of `retweet`, `reply` and `quote`.
+  When the nodes are users, the sum of `retweet`, `reply`, `quote` and `mention`.
   When the nodes are hashtags,
   the number of tweets that contained both hashtags.
 

--- a/test_twarc_network.py
+++ b/test_twarc_network.py
@@ -16,16 +16,16 @@ def test_html():
     m = re.search(r"var graph = ({.*});.*var link = ", result.output, re.DOTALL)
     assert m
     graph = json.loads(m.group(1))
-    assert len(graph["nodes"]) == 484
-    assert len(graph["links"]) == 391
+    assert len(graph["nodes"]) == 656
+    assert len(graph["links"]) == 618
 
 
 def test_json():
     result = runner.invoke(network, ["test-data/tweets.jsonl", "--format", "json"])
     assert result.exit_code == 0
     graph = json.loads(result.output)
-    assert len(graph["nodes"]) == 484
-    assert len(graph["links"]) == 391
+    assert len(graph["nodes"]) == 656
+    assert len(graph["links"]) == 618
 
 
 def test_gexf():
@@ -44,8 +44,8 @@ def test_dot():
     graphs = pydot.graph_from_dot_data(result.output)
     assert len(graphs) == 1
     graph = graphs[0]
-    assert len(graph.get_node_list()) == 485
-    assert len(graph.get_edge_list()) == 391
+    assert len(graph.get_node_list()) == 657
+    assert len(graph.get_edge_list()) == 618
 
 
 def test_csv():
@@ -55,7 +55,7 @@ def test_csv():
     count = 0
     for row in data:
         count += 1
-    assert count == 391
+    assert count == 618
 
 
 def test_min_component():
@@ -64,7 +64,7 @@ def test_min_component():
         ["test-data/tweets.jsonl", "--format", "json", "--min-component-size", "4"],
     )
     graph = json.loads(result.output)
-    assert len(graph["nodes"]) == 285
+    assert len(graph["nodes"]) == 469
 
 
 def test_max_component():
@@ -73,7 +73,7 @@ def test_max_component():
         ["test-data/tweets.jsonl", "--format", "json", "--max-component-size", "15"],
     )
     graph = json.loads(result.output)
-    assert len(graph["nodes"]) == 313
+    assert len(graph["nodes"]) == 355
 
 
 def test_tweets():
@@ -92,3 +92,17 @@ def test_hashtags():
     assert result.exit_code == 0
     graph = json.loads(result.output)
     assert len(graph["nodes"]) == 383
+
+
+def test_edges():
+    result = runner.invoke(
+        network,
+        [
+            "test-data/tweets.jsonl", "--format", "json", "--edges", "retweet",
+            "--edges", "reply", "--edges", "quote"
+        ]
+    )
+    assert result.exit_code == 0
+    graph = json.loads(result.output)
+    assert len(graph["nodes"]) == 484
+    assert len(graph["links"]) == 391

--- a/twarc_network/index.html
+++ b/twarc_network/index.html
@@ -27,6 +27,11 @@
       stroke-width: 3px;
     }
 
+    line.mention {
+      stroke: red;
+      stroke-width: 3px;
+    }
+
     .nodes circle {
       stroke: black;
       fill: #ccc;


### PR DESCRIPTION
I add mention edges: When a user A mentions a user B in a tweet, an edge between A and B is created. This change is bigger than the other I have made, so I open this pull request because maybe @edsu or anyone wants to review it?

We could imagine the code to be quite trivial (just looking to `tweet["entities"]["mentions"]`), but it is a bit more complex: When A retweets B, B is also included in `tweet_A["entities"]["mentions"]`, because the text of tweet_A is `RT @B: tweet_B`. I tried to do a simple operation (real_mentions = mentions - retweets), but this is also incorrect in the case where B has changed its username between the retweet and the data download. In this case, in `RT @old_B: tweet_B` there is no mention to any user so B is not included in `tweet_A["entities"]["mentions"]`. So at the end I made the function `is_first_mention_a_retweet` to check it properly: if the tweet is a retweet and the first mention starts at position 3 (after `RT `), then this mention is not a real mention, but a retweet, so we do not count it.